### PR TITLE
Feature/38 Light/Dark Mode에서 동일한 Appearance로 보이도록 수정

### DIFF
--- a/NineInTeam/NineInTeam.xcodeproj/project.pbxproj
+++ b/NineInTeam/NineInTeam.xcodeproj/project.pbxproj
@@ -291,10 +291,10 @@
 		DE6FBDE42990E82700816A7D /* Main */ = {
 			isa = PBXGroup;
 			children = (
-				DE5E998A29D477D900D32B8E /* ProfileEdit */,
-				DE7B0B7629D8847100CB90FE /* ChatList */,
 				DE6FBDE52990E83400816A7D /* MainView.swift */,
 				DEB0D36E29BF4FE900B5E1B9 /* BottomNavigationItem.swift */,
+				DE5E998A29D477D900D32B8E /* ProfileEdit */,
+				DE7B0B7629D8847100CB90FE /* ChatList */,
 				DEB0D35A29AF7E3D00B5E1B9 /* Home */,
 				39BD81D329E402B900F35E0B /* ReceivedPost */,
 				DEB0D35B29AF7E4500B5E1B9 /* MySubscribe */,

--- a/NineInTeam/NineInTeam.xcodeproj/project.pbxproj
+++ b/NineInTeam/NineInTeam.xcodeproj/project.pbxproj
@@ -286,6 +286,16 @@
 			path = ReceivedPost;
 			sourceTree = "<group>";
 		};
+		39D6560029F184FF00C17C1B /* Tag */ = {
+			isa = PBXGroup;
+			children = (
+				39D655FA29F17C4300C17C1B /* SubscribeTagView.swift */,
+				39D655FC29F17C5400C17C1B /* SubscribeTagCell.swift */,
+				39D655FE29F17D1F00C17C1B /* SubscribeTagViewModel.swift */,
+			);
+			path = Tag;
+			sourceTree = "<group>";
+		};
 		DE47790A29F169FC00C0EC3E /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
@@ -301,16 +311,6 @@
 				DE47790D29F4005700C0EC3E /* Destination.swift */,
 			);
 			path = Destination;
-      sourceTree = "<group>";
-		};
-		39D6560029F184FF00C17C1B /* Tag */ = {
-			isa = PBXGroup;
-			children = (
-				39D655FA29F17C4300C17C1B /* SubscribeTagView.swift */,
-				39D655FC29F17C5400C17C1B /* SubscribeTagCell.swift */,
-				39D655FE29F17D1F00C17C1B /* SubscribeTagViewModel.swift */,
-			);
-			path = Tag;
 			sourceTree = "<group>";
 		};
 		DE5E998A29D477D900D32B8E /* ProfileEdit */ = {
@@ -1105,6 +1105,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1139,6 +1140,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/NineInTeam/NineInTeam/Extension/View.swift
+++ b/NineInTeam/NineInTeam/Extension/View.swift
@@ -19,6 +19,7 @@ extension View {
             
             self
                 .padding(.bottom, 10)
+                .padding(.horizontal, 10)
                 .background(Color(hexcode: "FFFFFF"))
                 .navigationBarHiddenTrue()
             
@@ -39,6 +40,7 @@ extension View {
             
             self
                 .padding(.bottom, 10)
+                .padding(.horizontal, 10)
                 .background(Color(hexcode: "FFFFFF"))
                 .navigationBarHiddenTrue()
             

--- a/NineInTeam/NineInTeam/Extension/View.swift
+++ b/NineInTeam/NineInTeam/Extension/View.swift
@@ -19,7 +19,7 @@ extension View {
             
             self
                 .padding(.bottom, 10)
-                .padding(.horizontal, 10)
+                .background(Color(hexcode: "FFFFFF"))
                 .navigationBarHiddenTrue()
             
             Spacer()

--- a/NineInTeam/NineInTeam/Extension/View.swift
+++ b/NineInTeam/NineInTeam/Extension/View.swift
@@ -39,7 +39,7 @@ extension View {
             
             self
                 .padding(.bottom, 10)
-                .padding(.horizontal, 10)
+                .background(Color(hexcode: "FFFFFF"))
                 .navigationBarHiddenTrue()
             
             Spacer()

--- a/NineInTeam/NineInTeam/NineInTeam-Info.plist
+++ b/NineInTeam/NineInTeam/NineInTeam-Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>KAKAO_APP_KEY</key>
-	<string>78b20efcbe4535ce48a5ee2c4739745a</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -15,6 +13,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>KAKAO_APP_KEY</key>
+	<string>78b20efcbe4535ce48a5ee2c4739745a</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/NineInTeam/NineInTeam/Presentation/Main/Home/WritePost/WritePostView.swift
+++ b/NineInTeam/NineInTeam/Presentation/Main/Home/WritePost/WritePostView.swift
@@ -116,6 +116,7 @@ extension WritePostView {
                         TextWithFont(text: tag, font: .regular, size: 13)
                             .padding(.vertical, 6)
                             .padding(.horizontal, 10)
+                            .foregroundColor(Color(hexcode: "000000"))
                             .background(
                                 Capsule(style: .continuous)
                                     .stroke(Color(hexcode: "000000").opacity(0.26))
@@ -233,6 +234,7 @@ extension WritePostView {
             ScrollView {
                 // TextField로 변경
                 TextWithFont(text: "asdf\nasdfa]nasdfa\nadf\nasdfasd\nasdf", font: .regular, size: 16)
+                    .foregroundColor(Color(hexcode: "000000"))
             }
             .padding(.vertical, 16)
             .padding(.horizontal, 12)
@@ -372,4 +374,12 @@ extension WritePostView {
         }
     }
     
+}
+
+struct WritePostView_Previews: PreviewProvider {
+    static var previews: some View {
+
+        WritePostView()
+
+    }
 }

--- a/NineInTeam/NineInTeam/Presentation/Main/MainView.swift
+++ b/NineInTeam/NineInTeam/Presentation/Main/MainView.swift
@@ -61,6 +61,7 @@ extension MainView {
                             selection = 3
                         }
                 }
+                .background(Color(hexcode: "FFFFFF"))
                 .frame(height: 60)
             }            
         }

--- a/NineInTeam/NineInTeam/Presentation/Main/MySubscribe/Tag/SubscribeTagCell.swift
+++ b/NineInTeam/NineInTeam/Presentation/Main/MySubscribe/Tag/SubscribeTagCell.swift
@@ -25,6 +25,7 @@ extension SubscribeTagCell {
             HStack {
                 VStack(alignment: .leading, spacing: 0) {
                     TextWithFont(text: "#알고리즘", font: .regular, size: 16)
+                        .foregroundColor(Color(hexcode: "000000"))
                         .frame(height: 24)
 
                     TextWithFont(text: "구독자 123명", font: .regular, size: 12)


### PR DESCRIPTION
Light/Dark Mode에서 동일한 Appearance로 보이도록 수정 #38

UIHostingController 내 backgroundColor가 작동하지 않아 
그래서, 우선 info.plist에 Appearance Light로 반영하여 Pull Request 드립니다.



---

사실 Dark모드를 사용하지않으니 Appearance를 Light로 fix하는 방법이 가장 좋은 것 같긴합니다.
아래 문제 해결시 추후 Dark Mode 사용하는 앱에서 이 문제를 해결할 때 도움이 될 것 같습니다.

### 하위계층 HostingViewController의 BackgroundColor가 노출됨
<img width="400" alt="image" src="https://user-images.githubusercontent.com/60867281/236665804-ba9a51e6-96ed-4f31-9c6e-6ab44cf7d2e5.png">

### View의 하단이 Black색상으로 표현됨
<img width="400" alt="image" src="https://user-images.githubusercontent.com/60867281/236665840-185734d5-5993-408b-b2e9-5f97c4f24c9c.png">

close #38